### PR TITLE
Add startup entrypoint to handle migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,5 @@ RUN apt-get update && apt-get install -y build-essential libjpeg-dev zlib1g-dev 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
+RUN chmod +x /app/entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes: [".:/app", "media:/var/app/media"]
     ports: ["8000:8000"]
     depends_on: [db, redis]
-    command: bash -lc "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    command: python manage.py runserver 0.0.0.0:8000
 
   worker:
     build: .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+python manage.py makemigrations
+python manage.py migrate --noinput
+python manage.py collectstatic --noinput || true
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add shell entrypoint that runs makemigrations, migrate and collectstatic before executing container command
- configure Dockerfile to use the entrypoint and make web service rely on it for migrations

## Testing
- `docker-compose build` *(fails: ModuleNotFoundError: No module named 'distutils')*
- `docker-compose up` *(fails: ConnectionRefusedError: [Errno 111] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c3050b9ed0832fbe2c68378a7fcbbf