### PR TITLE
Set BigAutoField as default primary key

### DIFF
--- a/content_manager/settings.py
+++ b/content_manager/settings.py
@@ -10,6 +10,7 @@ DEBUG = bool(int(os.getenv("DEBUG", 1)))
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 TIME_ZONE = os.getenv("TIME_ZONE", "Europe/Warsaw")
 USE_TZ = True
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 INSTALLED_APPS = [
     "jazzmin",


### PR DESCRIPTION
## Summary
- default all models to BigAutoField

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c3133c96d4832f8e17fb580aed32ca