### PR TITLE
Style admin posts as Telegram cards

### DIFF
--- a/apps/posts/admin.py
+++ b/apps/posts/admin.py
@@ -1,15 +1,49 @@
-from django.contrib import admin, messages
-from django.contrib.admin.helpers import ActionForm as AdminActionForm
+from pathlib import Path
+
 from django import forms
-from .models import Post, PostMedia, Channel, DraftPost, ScheduledPost
+from django.conf import settings
+from django.contrib import admin, messages
+from django.contrib.admin import helpers
+from django.contrib.admin.helpers import ActionForm as AdminActionForm
+from django.contrib.admin.widgets import AdminSplitDateTime
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+from django.utils import timezone
+
 from . import services
+from .models import Channel, DraftPost, Post, PostMedia, ScheduledPost
+from .tasks import task_gpt_generate_for_channel, task_gpt_rewrite_post
 from .validators import validate_post_text_for_channel
-from .tasks import task_gpt_rewrite_post, task_gpt_generate_for_channel
 
 
 
 class PostActionForm(AdminActionForm):
     prompt = forms.CharField(label="Prompt korekty (opcjonalny)", required=False)
+
+
+class RescheduleForm(forms.Form):
+    schedule_mode = forms.ChoiceField(
+        label="Tryb planowania",
+        choices=Post._meta.get_field("schedule_mode").choices,
+        help_text="Wybierz AUTO, aby nadać termin zgodnie z harmonogramem kanału.",
+    )
+    scheduled_at = forms.SplitDateTimeField(
+        label="Data publikacji",
+        required=False,
+        widget=AdminSplitDateTime(),
+        help_text="Dla trybu ręcznego ustaw dokładną datę i godzinę publikacji.",
+    )
+
+    def clean(self):
+        cleaned = super().clean()
+        mode = cleaned.get("schedule_mode")
+        dt = cleaned.get("scheduled_at")
+        if mode == "MANUAL" and not dt:
+            self.add_error("scheduled_at", "Podaj konkretną datę w trybie ręcznym.")
+        return cleaned
+
 
 class PostForm(forms.ModelForm):
     class Meta:
@@ -59,15 +93,114 @@ class BasePostAdmin(admin.ModelAdmin):
     list_filter = ("channel","status","schedule_mode")
     actions = ["act_fill_to_20","act_approve","act_schedule","act_publish_now","act_delete","act_gpt_rewrite"]
     ordering = ("-created_at",)
+    change_list_template = "admin/posts/post_cards.html"
+    reschedule_template = "admin/posts/reschedule.html"
 
     def short(self, obj): return obj.text[:80] + ("…" if len(obj.text)>80 else "")
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
+        qs = qs.select_related("channel", "approved_by").prefetch_related("media")
         return self.filter_queryset(qs)
 
     def filter_queryset(self, qs):
         return qs
+
+    def _object_url(self, obj, action):
+        opts = self.model._meta
+        return reverse(f"admin:{opts.app_label}_{opts.model_name}_{action}", args=[obj.pk])
+
+    def _media_to_url(self, media: PostMedia) -> str:
+        cache_path = (media.cache_path or "").strip()
+        if cache_path:
+            media_root = Path(settings.MEDIA_ROOT).resolve()
+            try:
+                rel = Path(cache_path).resolve().relative_to(media_root)
+                return settings.MEDIA_URL.rstrip("/") + "/" + rel.as_posix()
+            except ValueError:
+                pass
+        src = (media.source_url or "").strip()
+        return src
+
+    def _build_preview_media(self, post: Post) -> list[str]:
+        urls: list[str] = []
+        media_manager = getattr(post, "media", None)
+        if media_manager is None:
+            return urls
+        for media in media_manager.all():
+            url = self._media_to_url(media)
+            if url:
+                urls.append(url)
+        return urls
+
+    def changelist_view(self, request, extra_context=None):
+        response = super().changelist_view(request, extra_context=extra_context)
+        if hasattr(response, "context_data"):
+            cl = response.context_data.get("cl")
+            if cl:
+                response.context_data.setdefault("action_checkbox_name", helpers.ACTION_CHECKBOX_NAME)
+                for post in cl.result_list:
+                    post.preview_media = self._build_preview_media(post)
+                    post.change_url = self._object_url(post, "change")
+                    post.delete_url = self._object_url(post, "delete")
+                    post.reschedule_url = self._object_url(post, "reschedule")
+        return response
+
+    def get_urls(self):
+        urls = super().get_urls()
+        opts = self.model._meta
+        custom = [
+            path(
+                "<int:object_id>/przeloz/",
+                self.admin_site.admin_view(self.reschedule_view),
+                name=f"{opts.app_label}_{opts.model_name}_reschedule",
+            )
+        ]
+        return custom + urls
+
+    def reschedule_view(self, request, object_id):
+        post = get_object_or_404(self.model, pk=object_id)
+        if not self.has_change_permission(request, post):
+            raise PermissionDenied
+
+        tzinfo = timezone.get_current_timezone()
+        initial = {"schedule_mode": post.schedule_mode}
+        if post.scheduled_at:
+            local_dt = timezone.localtime(post.scheduled_at, tzinfo)
+            initial["scheduled_at"] = timezone.make_naive(local_dt, tzinfo)
+
+        form = RescheduleForm(request.POST or None, initial=initial)
+
+        if request.method == "POST" and form.is_valid():
+            mode = form.cleaned_data["schedule_mode"]
+            post.schedule_mode = mode
+            if mode == "AUTO":
+                services.assign_auto_slot(post)
+                msg = "Wyznaczono termin publikacji automatycznie."
+            else:
+                scheduled_at = form.cleaned_data.get("scheduled_at")
+                if scheduled_at:
+                    if timezone.is_naive(scheduled_at):
+                        scheduled_at = timezone.make_aware(scheduled_at, tzinfo)
+                    post.scheduled_at = scheduled_at
+                post.status = "SCHEDULED"
+                post.dupe_score = services.compute_dupe(post)
+                post.save()
+                msg = "Zmieniono termin publikacji."
+            self.message_user(request, msg, level=messages.SUCCESS)
+            changelist_url = reverse(f"admin:{self.model._meta.app_label}_{self.model._meta.model_name}_changelist")
+            return redirect(changelist_url)
+
+        context = {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "original": post,
+            "title": "Przełóż publikację",
+            "form": form,
+            "media": form.media,
+            "changelist_url": reverse(f"admin:{self.model._meta.app_label}_{self.model._meta.model_name}_changelist"),
+        }
+        return TemplateResponse(request, self.reschedule_template, context)
 
     @admin.action(description="Uzupełnij do 20 (bieżący kanał / wszystkie jeśli brak selekcji)")
     def act_fill_to_20(self, request, qs):

--- a/static/admin/post_cards.css
+++ b/static/admin/post_cards.css
@@ -1,0 +1,182 @@
+.post-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+  margin-top: 1.5rem;
+}
+
+.post-card {
+  position: relative;
+  background: var(--card-bg, #0f172a);
+  color: #f8fafc;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+body.dark-theme .post-card {
+  --card-bg: rgba(15, 17, 21, 0.92);
+  border-color: rgba(31, 41, 55, 0.65);
+}
+
+.post-card__head {
+  padding: 16px 20px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.post-card__channel {
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.post-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: rgba(226, 232, 240, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.post-card__status-badge {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.post-card[data-status="DRAFT"] .post-card__status-badge {
+  background: #fde68a;
+}
+
+.post-card[data-status="APPROVED"] .post-card__status-badge {
+  background: #a5b4fc;
+}
+
+.post-card[data-status="SCHEDULED"] .post-card__status-badge {
+  background: #facc15;
+}
+
+.post-card[data-status="PUBLISHED"] .post-card__status-badge {
+  background: #4ade80;
+}
+
+.post-card[data-status="REJECTED"] .post-card__status-badge {
+  background: #f87171;
+}
+
+.post-card__preview {
+  padding: 0 20px 16px;
+}
+
+.post-card__preview .tg-wrap {
+  width: 100%;
+  --w: 100%;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.35);
+}
+
+.post-card__meta {
+  padding: 0 20px 16px;
+  font-size: 13px;
+  color: rgba(226, 232, 240, 0.75);
+  display: grid;
+  gap: 4px;
+}
+
+.post-card__meta strong {
+  color: rgba(248, 250, 252, 0.9);
+  font-weight: 600;
+}
+
+.post-card__meta time {
+  font-feature-settings: "tnum";
+}
+
+.post-card__footer {
+  margin-top: auto;
+  padding: 16px 20px 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.post-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.post-card__actions a,
+.post-card__actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.post-card__action--primary {
+  background: #38bdf8;
+  color: #0f172a;
+}
+
+.post-card__action--secondary {
+  background: rgba(148, 163, 184, 0.15);
+  color: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.post-card__action--danger {
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.post-card__action--primary:hover {
+  background: #0ea5e9;
+}
+
+.post-card__action--secondary:hover {
+  background: rgba(148, 163, 184, 0.3);
+}
+
+.post-card__action--danger:hover {
+  background: rgba(248, 113, 113, 0.35);
+}
+
+.post-card__selection {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.post-card__selection input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+}
+
+@media (max-width: 960px) {
+  .post-card-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/templates/admin/posts/includes/post_card.html
+++ b/templates/admin/posts/includes/post_card.html
@@ -1,0 +1,57 @@
+{% load admin_urls tz %}
+{% localtime on %}
+<article class="post-card" data-status="{{ post.status }}">
+  <div class="post-card__head">
+    <div class="post-card__channel">
+      <span>{{ post.channel }}</span>
+      <span class="post-card__status">
+        <span class="post-card__status-badge">{{ post.get_status_display }}</span>
+        {% if post.schedule_mode %}
+          <span>{{ post.get_schedule_mode_display }}</span>
+        {% endif %}
+      </span>
+    </div>
+    {% if post.scheduled_at %}
+      <div class="post-card__status">
+        <strong>Publikacja:</strong>
+        <time datetime="{{ post.scheduled_at|date:'c' }}">{{ post.scheduled_at|date:"d.m.Y H:i" }}</time>
+      </div>
+    {% elif post.expires_at %}
+      <div class="post-card__status">
+        <strong>Wygasa:</strong>
+        <time datetime="{{ post.expires_at|date:'c' }}">{{ post.expires_at|date:"d.m.Y H:i" }}</time>
+      </div>
+    {% endif %}
+  </div>
+  <div class="post-card__preview">
+    {% include "partials/telegram_preview.html" with text=post.text media=post.preview_media width='100%' %}
+  </div>
+  <div class="post-card__meta">
+    <div>
+      <strong>ID:</strong> {{ post.pk }} • <strong>Duplikat:</strong>
+      {% if post.dupe_score is not None %}
+        {{ post.dupe_score|floatformat:2 }}
+      {% else %}
+        –
+      {% endif %}
+    </div>
+    <div><strong>Utworzono:</strong> <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|date:"d.m.Y H:i" }}</time></div>
+    {% if post.approved_by %}
+      <div><strong>Zatwierdził:</strong> {{ post.approved_by }}</div>
+    {% endif %}
+  </div>
+  <div class="post-card__footer">
+    <div class="post-card__actions">
+      <a href="{{ post.change_url }}" class="post-card__action--primary">Edytuj</a>
+      <a href="{{ post.reschedule_url }}" class="post-card__action--secondary">Przełóż publikację</a>
+      <a href="{{ post.delete_url }}" class="post-card__action--danger">Usuń</a>
+    </div>
+    {% if action_checkbox_name and cl.show_admin_actions %}
+    <label class="post-card__selection">
+      <input type="checkbox" class="action-select" name="{{ action_checkbox_name }}" value="{{ post.pk }}">
+      <span>Do akcji</span>
+    </label>
+    {% endif %}
+  </div>
+</article>
+{% endlocaltime %}

--- a/templates/admin/posts/post_cards.html
+++ b/templates/admin/posts/post_cards.html
@@ -1,0 +1,24 @@
+{% extends "admin/change_list.html" %}
+{% load static admin_list %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'admin/post_cards.css' %}">
+{% endblock %}
+
+{% block result_list %}
+  {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+  <div class="results">
+    {% if cl.formset %}
+      {{ cl.formset.management_form }}
+    {% endif %}
+    <div class="post-card-grid">
+      {% for post in cl.result_list %}
+        {% include "admin/posts/includes/post_card.html" with post=post action_checkbox_name=action_checkbox_name cl=cl %}
+      {% empty %}
+        <p>Brak wpisów do wyświetlenia.</p>
+      {% endfor %}
+    </div>
+  </div>
+  {% if action_form and actions_on_bottom and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+{% endblock %}

--- a/templates/admin/posts/reschedule.html
+++ b/templates/admin/posts/reschedule.html
@@ -1,0 +1,36 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media }}
+{% endblock %}
+
+{% block content %}
+  <div id="content" class="content">
+    <h1>{{ title }}</h1>
+    <div id="content-main">
+      <form method="post" novalidate>
+        {% csrf_token %}
+        <fieldset class="module aligned">
+          <div class="form-row field-schedule_mode">
+            {{ form.schedule_mode.errors }}
+            <label for="{{ form.schedule_mode.id_for_label }}">{{ form.schedule_mode.label }}:</label>
+            {{ form.schedule_mode }}
+            {% if form.schedule_mode.help_text %}<p class="help">{{ form.schedule_mode.help_text }}</p>{% endif %}
+          </div>
+          <div class="form-row field-scheduled_at">
+            {{ form.scheduled_at.errors }}
+            <label for="{{ form.scheduled_at.id_for_label }}">{{ form.scheduled_at.label }}:</label>
+            {{ form.scheduled_at }}
+            {% if form.scheduled_at.help_text %}<p class="help">{{ form.scheduled_at.help_text }}</p>{% endif %}
+          </div>
+        </fieldset>
+        <div class="submit-row">
+          <a class="button cancel-link" href="{{ changelist_url }}">Anuluj</a>
+          <button type="submit" class="default">Zapisz zmiany</button>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/templates/partials/telegram_preview.html
+++ b/templates/partials/telegram_preview.html
@@ -1,4 +1,4 @@
-<div class="tg-wrap" style="--w:360px" data-theme="dark">
+<div class="tg-wrap" style="--w:{{ width|default:'360px' }}" data-theme="{{ theme|default:'dark' }}">
   {% if media and media|length == 1 %}
     <div class="tg-media"><img src="{{ media.0 }}" alt=""></div>
   {% elif media and media|length == 2 %}


### PR DESCRIPTION
## Summary
- restyle the Draft and Harmonogram change lists to show Telegram-like cards with inline actions
- add per-post edit/delete/reschedule shortcuts backed by a dedicated reschedule admin view
- make the Telegram preview partial reusable with dynamic width settings and ship supporting styles

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d58487b078832792a77c7fe1ea65e4