### PR TITLE
Handle missing Telegram bot tokens

### DIFF
--- a/apps/posts/services.py
+++ b/apps/posts/services.py
@@ -16,7 +16,9 @@ from dateutil import tz
 
 
 def _bot_for(channel: Channel):
-    token = channel.bot_token or settings.TG_BOT_TOKEN
+    token = (channel.bot_token or "").strip()
+    if not token:
+        return None
     return Bot(token=token)
 
 _oai = None

--- a/apps/posts/tests/test_publish_without_token.py
+++ b/apps/posts/tests/test_publish_without_token.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.posts import tasks
+from apps.posts.models import Channel, Post
+
+
+class PublishWithoutTokenTest(TestCase):
+    def test_publish_skips_when_bot_missing(self):
+        channel = Channel.objects.create(
+            name="Test channel",
+            slug="test",
+            tg_channel_id="@test",
+            bot_token=" ",
+        )
+        post = Post.objects.create(
+            channel=channel,
+            text="Hello world",
+            status="SCHEDULED",
+            scheduled_at=timezone.now(),
+        )
+
+        with patch("apps.posts.services.Bot") as bot_cls, \
+             patch("apps.posts.tasks.logger.warning") as mock_warning, \
+             patch("apps.posts.tasks.services.compute_dupe") as mock_compute:
+            result = tasks.publish_post(post.id)
+
+        bot_cls.assert_not_called()
+        mock_compute.assert_not_called()
+        mock_warning.assert_called_once()
+
+        post.refresh_from_db()
+        self.assertEqual(post.status, "SCHEDULED")
+        self.assertIsNone(post.message_id)
+        self.assertIsNone(result)


### PR DESCRIPTION
## Summary
- update Telegram bot lookup to rely solely on the channel token and skip when missing
- prevent publish task from sending messages without a bot and keep posts scheduled
- add a regression test covering the missing token scenario

## Testing
- python manage.py test apps.posts.tests.test_publish_without_token -v 2

------
https://chatgpt.com/codex/tasks/task_e_68d5bd6defbc832781020c4ce75ad92c