### PR TITLE
Simplify footer instructions in channel prompts

### DIFF
--- a/apps/posts/services.py
+++ b/apps/posts/services.py
@@ -222,10 +222,13 @@ def gpt_generate_post_payload(channel: Channel, article: dict[str, Any] | None =
         "do tematu (np. myśliwiec F-16 dla wiadomości o rakietach).",
         "Dla wideo/dokumentów zawsze podawaj pełny url.",
     ]
-    channel_rules = _channel_constraints_prompt(channel).strip()
-    if channel_rules:
-        instructions.append("Stosuj się do następujących wytycznych kanału:")
-        instructions.append(channel_rules)
+    if channel.max_chars:
+        instructions.append(
+            "Długość odpowiedzi musi mieścić się w limicie znaków opisanym w systemowym promptcie."
+        )
+    instructions.append(
+        "Uwzględnij wymagania dotyczące emoji, stopki i zakazów opisane w systemowym promptcie."
+    )
     if article_context:
         instructions.append("Korzystaj z poniższych danych artykułu:")
         instructions.append(article_context)
@@ -241,12 +244,10 @@ def gpt_generate_post_payload(channel: Channel, article: dict[str, Any] | None =
 
 def gpt_rewrite_text(channel: Channel, text: str, editor_prompt: str) -> str:
     sys = _channel_system_prompt(channel)
-    channel_rules = _channel_constraints_prompt(channel).strip()
-    extra_rules = f"\n\nWytyczne kanału:\n{channel_rules}" if channel_rules else ""
     usr = (
         "Przepisz poniższy tekst zgodnie z zasadami i wytycznymi edytora. "
-        "Zachowaj charakter kanału, wymagania dotyczące długości, emoji oraz stopki."
-        f"{extra_rules}\n\n[Wytyczne edytora]: {editor_prompt}\n\n[Tekst]:\n{text}"
+        "Zachowaj charakter kanału, wymagania dotyczące długości, emoji oraz stopki opisane w systemowym promptcie."
+        f"\n\n[Wytyczne edytora]: {editor_prompt}\n\n[Tekst]:\n{text}"
     )
     return gpt_generate_text(sys, usr)
 

--- a/apps/posts/services.py
+++ b/apps/posts/services.py
@@ -39,9 +39,30 @@ def _client():
         _oai = OpenAI(api_key=key, max_retries=0, timeout=30)
     return _oai
 
+def _channel_constraints_prompt(ch: Channel) -> str:
+    rules: list[str] = []
+    language = (ch.language or "").strip()
+    if language:
+        rules.append(f"Piszesz w języku: {language}.")
+    rules.append(f"Limit długości tekstu: maksymalnie {ch.max_chars} znaków.")
+    rules.append(
+        f"Liczba emoji w treści: co najmniej {ch.emoji_min}, najwyżej {ch.emoji_max}."
+    )
+    footer = (ch.footer_text or "").strip()
+    if footer:
+        rules.append("Stopka kanału:")
+        rules.append(footer)
+    if ch.no_links_in_text:
+        rules.append("Nie dodawaj linków w treści posta.")
+    return "\n".join(rules)
+
+
 def _channel_system_prompt(ch: Channel) -> str:
-    return (ch.style_prompt or
-            "Piszesz WYŁĄCZNIE po polsku. 1–3 akapity, ⚡️ lead, bez linków, stopka w 2 liniach.")
+    base = (ch.style_prompt or "").strip()
+    rules = _channel_constraints_prompt(ch).strip()
+    if rules:
+        return f"{base}\n\nWytyczne kanału:\n{rules}"
+    return base
 
 
 def _strip_code_fence(raw: str) -> str:
@@ -201,8 +222,10 @@ def gpt_generate_post_payload(channel: Channel, article: dict[str, Any] | None =
         "do tematu (np. myśliwiec F-16 dla wiadomości o rakietach).",
         "Dla wideo/dokumentów zawsze podawaj pełny url.",
     ]
-    if channel.no_links_in_text:
-        instructions.append("Nie dodawaj linków w treści post_text.")
+    channel_rules = _channel_constraints_prompt(channel).strip()
+    if channel_rules:
+        instructions.append("Stosuj się do następujących wytycznych kanału:")
+        instructions.append(channel_rules)
     if article_context:
         instructions.append("Korzystaj z poniższych danych artykułu:")
         instructions.append(article_context)
@@ -218,9 +241,13 @@ def gpt_generate_post_payload(channel: Channel, article: dict[str, Any] | None =
 
 def gpt_rewrite_text(channel: Channel, text: str, editor_prompt: str) -> str:
     sys = _channel_system_prompt(channel)
-    usr = ("Przepisz poniższy tekst zgodnie z zasadami i wytycznymi edytora. "
-           "Zachowaj polski język, lead ⚡️, bez linków; nie usuwaj stopki kanału.\n\n"
-           f"[Wytyczne edytora]: {editor_prompt}\n\n[Tekst]:\n{text}")
+    channel_rules = _channel_constraints_prompt(channel).strip()
+    extra_rules = f"\n\nWytyczne kanału:\n{channel_rules}" if channel_rules else ""
+    usr = (
+        "Przepisz poniższy tekst zgodnie z zasadami i wytycznymi edytora. "
+        "Zachowaj charakter kanału, wymagania dotyczące długości, emoji oraz stopki."
+        f"{extra_rules}\n\n[Wytyczne edytora]: {editor_prompt}\n\n[Tekst]:\n{text}"
+    )
     return gpt_generate_text(sys, usr)
 
 

--- a/apps/posts/tests/__init__.py
+++ b/apps/posts/tests/__init__.py
@@ -1,0 +1,10 @@
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "content_manager.settings")
+
+try:
+    import django
+    django.setup()
+except Exception:  # pragma: no cover
+    # Allow pytest to continue if Django is already set up elsewhere.
+    pass

--- a/apps/posts/tests/test_channel_prompts.py
+++ b/apps/posts/tests/test_channel_prompts.py
@@ -35,12 +35,11 @@ class ChannelPromptPropagationTest(TestCase):
         self.assertIn("linia2", system_prompt)
         self.assertIn("Nie dodawaj linków", system_prompt)
 
-        self.assertIn("Stosuj się do następujących wytycznych kanału", user_prompt)
-        self.assertIn("maksymalnie 321 znaków", user_prompt)
-        self.assertIn("Liczba emoji", user_prompt)
-        self.assertIn("linia1", user_prompt)
-        self.assertIn("linia2", user_prompt)
-        self.assertIn("Nie dodawaj linków", user_prompt)
+        self.assertIn("limicie znaków", user_prompt)
+        self.assertIn("emoji, stopki i zakazów", user_prompt)
+        self.assertNotIn("linia1", user_prompt)
+        self.assertNotIn("linia2", user_prompt)
+        self.assertNotIn("Nie dodawaj linków", user_prompt)
 
     def test_rewrite_text_uses_same_channel_rules(self):
         with patch("apps.posts.services.gpt_generate_text") as mock_gpt:
@@ -53,9 +52,8 @@ class ChannelPromptPropagationTest(TestCase):
         self.assertIn("linia2", system_prompt)
         self.assertIn("Nie dodawaj linków", system_prompt)
 
-        self.assertIn("Wytyczne kanału", user_prompt)
-        self.assertIn("maksymalnie 321 znaków", user_prompt)
-        self.assertIn("Liczba emoji", user_prompt)
-        self.assertIn("linia1", user_prompt)
-        self.assertIn("linia2", user_prompt)
-        self.assertIn("Nie dodawaj linków", user_prompt)
+        self.assertIn("Zachowaj charakter kanału", user_prompt)
+        self.assertIn("długości, emoji oraz stopki", user_prompt)
+        self.assertNotIn("linia1", user_prompt)
+        self.assertNotIn("linia2", user_prompt)
+        self.assertNotIn("Nie dodawaj linków", user_prompt)

--- a/apps/posts/tests/test_channel_prompts.py
+++ b/apps/posts/tests/test_channel_prompts.py
@@ -1,0 +1,61 @@
+import json
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.posts import services
+from apps.posts.models import Channel
+
+
+class ChannelPromptPropagationTest(TestCase):
+    def setUp(self):
+        self.channel = Channel.objects.create(
+            name="Kanał testowy",
+            slug="kanał-testowy",
+            tg_channel_id="@kanal",
+            language="pl",
+            max_chars=321,
+            emoji_min=2,
+            emoji_max=4,
+            footer_text="linia1\nlinia2",
+            no_links_in_text=True,
+            style_prompt="Dostosuj ton do kanału.",
+        )
+
+    def test_generate_payload_adds_channel_rules_to_prompts(self):
+        with patch("apps.posts.services.gpt_generate_text") as mock_gpt:
+            mock_gpt.return_value = json.dumps({"post_text": "tekst", "media": []})
+            services.gpt_generate_post_payload(self.channel)
+
+        system_prompt, user_prompt = mock_gpt.call_args[0][:2]
+        self.assertIn("Wytyczne kanału", system_prompt)
+        self.assertIn("maksymalnie 321 znaków", system_prompt)
+        self.assertIn("Liczba emoji", system_prompt)
+        self.assertIn("linia1", system_prompt)
+        self.assertIn("linia2", system_prompt)
+        self.assertIn("Nie dodawaj linków", system_prompt)
+
+        self.assertIn("Stosuj się do następujących wytycznych kanału", user_prompt)
+        self.assertIn("maksymalnie 321 znaków", user_prompt)
+        self.assertIn("Liczba emoji", user_prompt)
+        self.assertIn("linia1", user_prompt)
+        self.assertIn("linia2", user_prompt)
+        self.assertIn("Nie dodawaj linków", user_prompt)
+
+    def test_rewrite_text_uses_same_channel_rules(self):
+        with patch("apps.posts.services.gpt_generate_text") as mock_gpt:
+            services.gpt_rewrite_text(self.channel, "oryginalny tekst", "edytor")
+
+        system_prompt, user_prompt = mock_gpt.call_args[0][:2]
+        self.assertIn("Wytyczne kanału", system_prompt)
+        self.assertIn("maksymalnie 321 znaków", system_prompt)
+        self.assertIn("linia1", system_prompt)
+        self.assertIn("linia2", system_prompt)
+        self.assertIn("Nie dodawaj linków", system_prompt)
+
+        self.assertIn("Wytyczne kanału", user_prompt)
+        self.assertIn("maksymalnie 321 znaków", user_prompt)
+        self.assertIn("Liczba emoji", user_prompt)
+        self.assertIn("linia1", user_prompt)
+        self.assertIn("linia2", user_prompt)
+        self.assertIn("Nie dodawaj linków", user_prompt)


### PR DESCRIPTION
## Summary
- stop adding hardcoded formatting guidance around the channel footer and pass it verbatim within the prompt rules

## Testing
- PYTHONPATH=. python manage.py test apps.posts.tests.test_channel_prompts apps.posts.tests.test_publish_without_token

------
https://chatgpt.com/codex/tasks/task_e_68d5c6e6fcf08327a712ade549a5ebe4