### PR TITLE
Proxy static and media paths to backend

### DIFF
--- a/deploy/nginx/content.run.place
+++ b/deploy/nginx/content.run.place
@@ -1,0 +1,55 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name content.run.place;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name content.run.place;
+
+    # certy — certbot je podmieni
+    ssl_certificate     /etc/letsencrypt/live/content.run.place/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/content.run.place/privkey.pem;
+
+    client_max_body_size 25m;
+    proxy_read_timeout   75s;
+    proxy_send_timeout   75s;
+
+    # statyki i media przekazywane do backendu
+    location /static/ {
+        proxy_pass           http://127.0.0.1:8000;
+        proxy_set_header     Host $host;
+        proxy_set_header     X-Real-IP $remote_addr;
+        proxy_set_header     X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header     X-Forwarded-Proto https;
+        proxy_redirect       off;
+    }
+
+    location /media/ {
+        proxy_pass           http://127.0.0.1:8000;
+        proxy_set_header     Host $host;
+        proxy_set_header     X-Real-IP $remote_addr;
+        proxy_set_header     X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header     X-Forwarded-Proto https;
+        proxy_redirect       off;
+    }
+
+    location / {
+        proxy_pass           http://127.0.0.1:8000;
+        proxy_set_header     Host $host;
+        proxy_set_header     X-Real-IP $remote_addr;
+        proxy_set_header     X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header     X-Forwarded-Proto https;
+        proxy_redirect       off;
+    }
+}


### PR DESCRIPTION
## Summary
- restore the HTTP challenge location block while keeping the HTTPS redirect
- replace the /static/ and /media/ aliases with proxy_pass directives to the backend
- retain the existing TLS and proxy tuning from the production configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5cb85a4c8832780905cccd66ceab4