### PR TITLE
Add approve action for drafts and auto scheduling

### DIFF
--- a/apps/posts/admin.py
+++ b/apps/posts/admin.py
@@ -237,6 +237,10 @@ class BasePostAdmin(admin.ModelAdmin):
         opts = self.model._meta
         return reverse(f"admin:{opts.app_label}_{opts.model_name}_{action}", args=[obj.pk])
 
+    def _changelist_url(self):
+        opts = self.model._meta
+        return reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
+
     def _media_to_url(self, media: PostMedia) -> str:
         return media_public_url(media)
 
@@ -358,7 +362,12 @@ class BasePostAdmin(admin.ModelAdmin):
                     post.delete_url = self._object_url(post, "delete")
                     post.reschedule_url = self._object_url(post, "reschedule")
                     post.rewrite_url = self._object_url(post, "rewrite")
+                    post.approve_url = self.get_approve_url(post)
+                    post.is_draft = post.status == Post.Status.DRAFT
         return response
+
+    def get_approve_url(self, post):
+        return None
 
     def get_urls(self):
         urls = super().get_urls()
@@ -470,8 +479,7 @@ class BasePostAdmin(admin.ModelAdmin):
     @admin.action(description="Zatwierdź i nadaj slot AUTO")
     def act_approve(self, request, qs):
         for p in qs:
-            p.status = "APPROVED"; p.approved_by = request.user; p.save()
-            services.assign_auto_slot(p)
+            services.approve_post(p, request.user)
 
     @admin.action(description="Przelicz slot AUTO")
     def act_schedule(self, request, qs):
@@ -488,8 +496,50 @@ class BasePostAdmin(admin.ModelAdmin):
 
 @admin.register(DraftPost)
 class DraftPostAdmin(BasePostAdmin):
+    approve_action = "approve"
+    approve_path = "<int:object_id>/akceptuj/"
+
     def filter_queryset(self, qs):
-        return qs.filter(status="DRAFT")
+        return qs.filter(status=Post.Status.DRAFT)
+
+    def get_urls(self):
+        urls = super().get_urls()
+        opts = self.model._meta
+        custom = [
+            path(
+                self.approve_path,
+                self.admin_site.admin_view(self.approve_view),
+                name=f"{opts.app_label}_{opts.model_name}_{self.approve_action}",
+            ),
+        ]
+        return custom + urls
+
+    def get_approve_url(self, post):
+        return self._object_url(post, self.approve_action)
+
+    def approve_view(self, request, object_id):
+        post = get_object_or_404(self.model, pk=object_id)
+        if not self.has_change_permission(request, post):
+            raise PermissionDenied
+
+        if request.method != "POST":
+            return redirect(self._changelist_url())
+
+        if post.status != Post.Status.DRAFT:
+            self.message_user(
+                request,
+                "Ten wpis nie jest już draftem.",
+                level=messages.WARNING,
+            )
+        else:
+            services.approve_post(post, request.user)
+            self.message_user(
+                request,
+                "Draft zatwierdzony i zaplanowany automatycznie.",
+                level=messages.SUCCESS,
+            )
+
+        return redirect(self._changelist_url())
 
 
 @admin.register(ScheduledPost)
@@ -499,7 +549,10 @@ class ScheduledPostAdmin(BasePostAdmin):
     date_hierarchy = "scheduled_at"
 
     def filter_queryset(self, qs):
-        return qs.filter(status__in=["APPROVED","SCHEDULED"], scheduled_at__isnull=False)
+        return qs.filter(
+            status__in=[Post.Status.APPROVED, Post.Status.SCHEDULED],
+            scheduled_at__isnull=False,
+        )
 
 
 @admin.register(PostMedia)

--- a/static/admin/post_cards.css
+++ b/static/admin/post_cards.css
@@ -119,6 +119,11 @@ body.dark-theme .post-card {
   gap: 8px;
 }
 
+.post-card__actions form {
+  display: contents;
+  margin: 0;
+}
+
 .post-card__actions a,
 .post-card__actions button {
   display: inline-flex;

--- a/templates/admin/posts/includes/post_card.html
+++ b/templates/admin/posts/includes/post_card.html
@@ -44,7 +44,14 @@
     <div class="post-card__actions">
       <a href="{{ post.change_url }}" class="post-card__action--primary">Edytuj</a>
       <a href="{{ post.rewrite_url }}" class="post-card__action--secondary">GPT: korekta</a>
-      <a href="{{ post.reschedule_url }}" class="post-card__action--secondary">Zmień termin publikacji</a>
+      {% if post.is_draft and post.approve_url %}
+        <form action="{{ post.approve_url }}" method="post">
+          {% csrf_token %}
+          <button type="submit" class="post-card__action--primary">Akceptuj</button>
+        </form>
+      {% else %}
+        <a href="{{ post.reschedule_url }}" class="post-card__action--secondary">Zmień termin publikacji</a>
+      {% endif %}
       <a href="{{ post.delete_url }}" class="post-card__action--danger">Usuń</a>
     </div>
     {% if action_checkbox_name and cl.show_admin_actions %}


### PR DESCRIPTION
## Summary
- replace the draft card reschedule action with an approve button that submits a POST
- introduce an admin view and service helper to mark drafts as approved and assign the next auto slot
- reuse Post status constants and admin URL helpers instead of hardcoded strings in the approval workflow

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d5d91251a883279b6490f1eae886a2