### PR TITLE
Handle OpenAI image URL responses

### DIFF
--- a/apps/posts/tests/test_media_generation.py
+++ b/apps/posts/tests/test_media_generation.py
@@ -1,0 +1,54 @@
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from django.test import TestCase, override_settings
+
+from apps.posts import services
+from apps.posts.models import Channel, Post, PostMedia
+
+
+class GeneratePhotoFallbackTest(TestCase):
+    def setUp(self):
+        self.channel = Channel.objects.create(
+            name="Kanał",
+            slug="kanal",
+            tg_channel_id="@kanal",
+        )
+        self.post = Post.objects.create(channel=self.channel, text="treść")
+
+    def test_downloads_image_when_only_url_is_returned(self):
+        media = PostMedia.objects.create(post=self.post, type="photo")
+        fake_payload = SimpleNamespace(
+            data=[SimpleNamespace(b64_json=None, url="http://example.com/image.png")]
+        )
+        mock_client = Mock()
+        mock_client.images.generate.return_value = fake_payload
+
+        class DummyHTTPResponse:
+            def __init__(self, body: bytes):
+                self.content = body
+
+            def raise_for_status(self):
+                return None
+
+        downloaded = DummyHTTPResponse(b"obrazek")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(MEDIA_ROOT=tmpdir):
+                with patch("apps.posts.services._client", return_value=mock_client):
+                    with patch("apps.posts.services.httpx.get", return_value=downloaded) as mock_get:
+                        cache_path = services._generate_photo_for_media(media, "prompt")
+
+                        self.assertTrue(cache_path)
+                        stored = Path(cache_path)
+                        self.assertTrue(stored.exists())
+                        self.assertEqual(stored.read_bytes(), b"obrazek")
+                        self.assertEqual(media.cache_path, cache_path)
+                        self.assertIsNotNone(media.expires_at)
+
+                        mock_client.images.generate.assert_called_once()
+                        call_kwargs = mock_client.images.generate.call_args.kwargs
+                        self.assertEqual(call_kwargs["response_format"], "b64_json")
+                        mock_get.assert_called_once_with("http://example.com/image.png", timeout=30)


### PR DESCRIPTION
## Summary
- wymuś zwracanie danych w base64 z OpenAI Images i pobieraj plik z URL w razie potrzeby
- zapisz bajty obrazu w pamięci podręcznej oraz aktualizuj metadane PostMedia
- dodaj test potwierdzający obsługę odpowiedzi zawierającej jedynie adres URL

## Testing
- python manage.py test apps.posts.tests.test_media_generation


------
https://chatgpt.com/codex/tasks/task_e_68d5ddb63b188327a038fcf8e0d0147f