### PR TITLE
Ensure consistent Content Manager title

### DIFF
--- a/content_manager/settings.py
+++ b/content_manager/settings.py
@@ -84,7 +84,7 @@ CELERY_BEAT_SCHEDULE = {
     "housekeeping": {"task": "apps.posts.tasks.task_housekeeping", "schedule": 3600.0},
 }
 
-PWA_APP_NAME = os.getenv("PWA_APP_NAME", "Content Manager – Panel")
+PWA_APP_NAME = os.getenv("PWA_APP_NAME", "Content Manager")
 PWA_THEME_COLOR = os.getenv("PWA_THEME_COLOR", "#111827")
 PWA_BACKGROUND_COLOR = os.getenv("PWA_BACKGROUND_COLOR", "#111827")
 PWA_START_URL = os.getenv("PWA_START_URL", "/admin/")

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,5 +1,11 @@
 {% extends "admin/base.html" %}
 {% load static %}
+{% block title %}Content Manager{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">Content Manager</a></h1>
+{% endblock %}
+
 {% block extrahead %}
 <link rel="manifest" href="/manifest.webmanifest">
 <meta name="theme-color" content="#111827">

--- a/templates/manifest.webmanifest
+++ b/templates/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Content Manager – Panel",
-  "short_name": "CM Panel",
+  "name": "Content Manager",
+  "short_name": "Content Manager",
   "start_url": "/admin/",
   "display": "standalone",
   "theme_color": "#111827",


### PR DESCRIPTION
## Summary
- ustawiono stały tytuł "Content Manager" w panelu admina
- ujednolicono nazwę aplikacji PWA oraz manifestu tak, by zawsze używała "Content Manager"

## Testing
- pytest *(niepowodzenie: ModuleNotFoundError: No module named 'apps')*


------
https://chatgpt.com/codex/tasks/task_e_68d701ce4a788327a25afef896b13bbe