### PR TITLE
Napraw automatyczne uzupełnianie draftów

### DIFF
--- a/apps/posts/drafts.py
+++ b/apps/posts/drafts.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+
+from django.db.models import Count, Q
+
+from .models import Channel, Post
+
+
+def iter_missing_draft_requirements(
+    channels: Iterable[Channel] | None = None,
+) -> Iterator[tuple[int, int]]:
+    """Yield ``(channel_id, missing_count)`` for channels below draft targets."""
+
+    channel_ids: set[int] | None = None
+    if channels is not None:
+        channel_ids = {ch.id for ch in channels if getattr(ch, "id", None)}
+        if not channel_ids:
+            return
+
+    queryset = Channel.objects.all()
+    if channel_ids is not None:
+        queryset = queryset.filter(id__in=channel_ids)
+
+    annotated = (
+        queryset.annotate(
+            draft_count=Count(
+                "posts",
+                filter=Q(posts__status=Post.Status.DRAFT),
+            )
+        )
+        .values("id", "draft_target_count", "draft_count")
+    )
+
+    for entry in annotated:
+        current = entry.get("draft_count") or 0
+        target = entry.get("draft_target_count") or 0
+        missing = max(target - current, 0)
+        if missing:
+            yield entry["id"], missing

--- a/apps/posts/services.py
+++ b/apps/posts/services.py
@@ -357,19 +357,6 @@ def create_post_from_payload(channel: Channel, payload: dict[str, Any]) -> Post:
     if isinstance(media_items, list):
         attach_media_from_payload(post, media_items)
     return post
-
-
-def ensure_min_drafts(channel: Channel):
-    need = channel.draft_target_count - channel.posts.filter(status="DRAFT").count()
-    created = 0
-    for _ in range(max(0, need)):
-        payload = gpt_new_draft(channel)
-        if payload is None:
-            break
-        create_post_from_payload(channel, payload)
-        created += 1
-    return created
-
 def compute_dupe(post: Post) -> float:
     texts = Post.objects.filter(status="PUBLISHED").order_by("-id").values_list("text", flat=True)[:300]
     if not texts: return 0.0


### PR DESCRIPTION
## Summary
- dodano wspólne obliczanie brakujących draftów i wykorzystano je w panelu oraz zadaniu okresowym
- zadanie Celery do uzupełniania draftów teraz zleca generowanie przez kolejkę zamiast wykonywać je synchronicznie
- usunięto nieużywany kod z usług, który duplikował logikę generowania draftów

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'apps')*

------
https://chatgpt.com/codex/tasks/task_e_68d7021df3ac832791305b4a40773408