### PR TITLE
Automatyczna zmiana statusu zaplanowanych wpisów

### DIFF
--- a/apps/posts/models.py
+++ b/apps/posts/models.py
@@ -66,6 +66,8 @@ class Post(models.Model):
         verbose_name_plural = "Wpisy"
 
     def save(self, *a, **kw):
+        if self.status == self.Status.APPROVED and self.scheduled_at:
+            self.status = self.Status.SCHEDULED
         if self.status == self.Status.DRAFT and not self.expires_at:
             ttl = getattr(self.channel, "draft_ttl_days", 3)
             self.expires_at = timezone.now() + timezone.timedelta(days=ttl)

--- a/apps/posts/tests/test_post_status_transitions.py
+++ b/apps/posts/tests/test_post_status_transitions.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.posts.models import Channel, Post
+
+
+class PostStatusTransitionsTest(TestCase):
+    def setUp(self):
+        self.channel = Channel.objects.create(
+            name="Kanał",
+            slug="kanal",
+            tg_channel_id="123",
+        )
+
+    def test_approved_post_with_schedule_becomes_scheduled(self):
+        post = Post.objects.create(
+            channel=self.channel,
+            text="Treść",
+            status=Post.Status.APPROVED,
+            scheduled_at=timezone.now(),
+        )
+
+        post.refresh_from_db()
+        self.assertEqual(post.status, Post.Status.SCHEDULED)
+
+    def test_approved_post_without_schedule_stays_approved(self):
+        post = Post.objects.create(
+            channel=self.channel,
+            text="Treść",
+            status=Post.Status.APPROVED,
+        )
+
+        post.refresh_from_db()
+        self.assertEqual(post.status, Post.Status.APPROVED)


### PR DESCRIPTION
## Podsumowanie
- automatyczna zmiana statusu wpisu z APPROVED na SCHEDULED w momencie nadania terminu publikacji
- dodanie testów regresyjnych dla zachowania statusu wpisu przy przypisywaniu lub braku terminu

## Testy
- python manage.py test apps.posts.tests.test_post_status_transitions


------
https://chatgpt.com/codex/tasks/task_e_68d7d3b5b68c8327860c439fb1002a23