### PR TITLE
Dodaj mobilny edytor i Vue datepicker

### DIFF
--- a/apps/posts/admin.py
+++ b/apps/posts/admin.py
@@ -85,6 +85,15 @@ class PostForm(forms.ModelForm):
         model = Post
         fields = ["channel","text","status","scheduled_at","schedule_mode"]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        text_field = self.fields.get("text")
+        if text_field is not None:
+            attrs = text_field.widget.attrs
+            attrs.setdefault("data-tg-editor", "1")
+            attrs.setdefault("data-tg-editor-compact", "0")
+            attrs.setdefault("placeholder", "Treść wpisu zgodna ze standardem Telegrama…")
+
     def clean(self):
         cleaned = super().clean()
         obj = self.instance
@@ -233,6 +242,15 @@ class RewritePromptForm(forms.Form):
         widget=forms.Textarea(attrs={"rows": 4}),
         help_text="Pozostaw puste, aby użyć domyślnej korekty stylu.",
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        prompt_field = self.fields.get("prompt")
+        if prompt_field is not None:
+            attrs = prompt_field.widget.attrs
+            attrs.setdefault("data-tg-editor", "1")
+            attrs.setdefault("data-tg-editor-compact", "1")
+            attrs.setdefault("placeholder", "Opcjonalny prompt dla GPT…")
 
 
 class BasePostAdmin(admin.ModelAdmin):

--- a/static/admin/post_edit.css
+++ b/static/admin/post_edit.css
@@ -11,8 +11,7 @@
 .post-edit__form fieldset.module{ border-radius:12px; border:1px solid rgba(148,163,184,0.3) }
 .post-edit__form fieldset.module h2{ font-size:16px; font-weight:600 }
 
-#id_text{ font-family:"JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  min-height:280px; font-size:14px; line-height:1.55 }
+#id_text{ font-family:"JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
 
 .inline-group{ margin-top:0 }
 .inline-group .post-media-inline{ border:1px solid rgba(148,163,184,0.35); border-radius:12px; padding:16px; margin-bottom:16px; background:#fff }

--- a/static/admin/post_form_tools.css
+++ b/static/admin/post_form_tools.css
@@ -1,0 +1,306 @@
+.tg-editor{
+  border:1px solid rgba(148,163,184,0.4);
+  border-radius:14px;
+  background:rgba(248,250,252,0.95);
+  box-shadow:inset 0 1px 1px rgba(15,23,42,0.04);
+  display:flex;
+  flex-direction:column;
+  overflow:hidden;
+}
+
+.tg-editor__toolbar{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  padding:12px 12px 8px;
+  background:rgba(241,245,249,0.85);
+  border-bottom:1px solid rgba(148,163,184,0.25);
+}
+
+.tg-editor__button{
+  appearance:none;
+  border:0;
+  background:#0f172a;
+  color:#f8fafc;
+  font-size:13px;
+  font-weight:600;
+  padding:10px 14px;
+  border-radius:10px;
+  display:flex;
+  align-items:center;
+  gap:6px;
+  cursor:pointer;
+  transition:transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow:0 6px 12px rgba(15,23,42,0.25);
+}
+
+.tg-editor__button:focus-visible{
+  outline:2px solid #38bdf8;
+  outline-offset:2px;
+}
+
+.tg-editor__button:hover{
+  transform:translateY(-1px);
+  box-shadow:0 12px 18px rgba(15,23,42,0.2);
+}
+
+.tg-editor__button.is-secondary{
+  background:#1e293b;
+  box-shadow:0 4px 10px rgba(15,23,42,0.2);
+}
+
+.tg-editor__button.is-danger{
+  background:#be123c;
+  box-shadow:0 4px 12px rgba(190,18,60,0.25);
+}
+
+.tg-editor__area{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+}
+
+.tg-editor__textarea{
+  width:100%;
+  border:0;
+  background:transparent;
+  font-family:"JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  min-height:260px;
+  font-size:15px;
+  line-height:1.6;
+  padding:16px;
+  resize:none;
+  color:#0f172a;
+}
+
+.tg-editor__textarea:focus{
+  outline:none;
+}
+
+.tg-editor__counter{
+  margin:0;
+  font-size:12px;
+  color:#475569;
+  padding:0 16px 12px;
+  text-align:right;
+}
+
+.tg-editor__counter[data-state="overflow"]{
+  color:#be123c;
+  font-weight:600;
+}
+
+body.dark-theme .tg-editor{
+  background:rgba(15,23,42,0.65);
+  border-color:rgba(148,163,184,0.5);
+  box-shadow:none;
+}
+
+body.dark-theme .tg-editor__toolbar{
+  background:rgba(30,41,59,0.9);
+  border-color:rgba(148,163,184,0.35);
+}
+
+body.dark-theme .tg-editor__button{
+  background:#2563eb;
+  color:#f8fafc;
+  box-shadow:0 10px 25px rgba(37,99,235,0.28);
+}
+
+body.dark-theme .tg-editor__button.is-secondary{
+  background:#0f172a;
+  box-shadow:0 6px 18px rgba(15,23,42,0.45);
+}
+
+body.dark-theme .tg-editor__button.is-danger{
+  background:#e11d48;
+  box-shadow:0 8px 18px rgba(225,29,72,0.45);
+}
+
+body.dark-theme .tg-editor__textarea{
+  color:#e2e8f0;
+}
+
+body.dark-theme .tg-editor__counter{
+  color:#cbd5f5;
+}
+
+.tg-editor[data-compact="1"] .tg-editor__textarea{
+  min-height:160px;
+}
+
+.tg-editor[data-compact="1"] .tg-editor__toolbar{
+  padding:10px;
+  gap:6px;
+}
+
+.tg-editor[data-compact="1"] .tg-editor__button{
+  padding:8px 12px;
+  font-size:12px;
+}
+
+@media (max-width: 720px){
+  .tg-editor__toolbar{
+    gap:6px;
+  }
+  .tg-editor__button{
+    flex:1 1 calc(50% - 6px);
+    justify-content:center;
+  }
+}
+
+.tg-datetime-picker{
+  margin-top:12px;
+  border:1px solid rgba(148,163,184,0.35);
+  border-radius:14px;
+  background:rgba(248,250,252,0.95);
+  padding:12px;
+  box-shadow:inset 0 1px 1px rgba(15,23,42,0.04);
+}
+
+.tg-datetime-picker__inner{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.tg-datetime-picker .dp__main{
+  width:100%;
+}
+
+.tg-datetime-picker .dp__input{
+  width:100%;
+  border-radius:12px;
+  border:1px solid rgba(148,163,184,0.4);
+  padding:12px 14px;
+  font-size:15px;
+  color:#0f172a;
+  background:#fff;
+}
+
+.tg-datetime-picker .dp__input:focus{
+  outline:none;
+  border-color:#2563eb;
+  box-shadow:0 0 0 3px rgba(37,99,235,0.2);
+}
+
+.tg-datetime-picker .dp__menu{
+  border-radius:16px;
+  border:1px solid rgba(148,163,184,0.35);
+  box-shadow:0 20px 40px rgba(15,23,42,0.25);
+  font-size:14px;
+}
+
+.tg-datetime-picker__header{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  margin-bottom:12px;
+  gap:12px;
+}
+
+.tg-datetime-picker__title{
+  font-size:14px;
+  font-weight:600;
+  color:#0f172a;
+  margin:0;
+}
+
+.tg-datetime-picker__actions{
+  display:flex;
+  gap:10px;
+  flex-wrap:wrap;
+}
+
+.tg-datetime-picker__link{
+  appearance:none;
+  border:0;
+  background:#2563eb;
+  color:#f8fafc;
+  font-weight:600;
+  padding:8px 14px;
+  border-radius:10px;
+  cursor:pointer;
+  box-shadow:0 8px 20px rgba(37,99,235,0.22);
+}
+
+.tg-datetime-picker__link.is-muted{
+  background:#1e293b;
+  box-shadow:0 6px 12px rgba(15,23,42,0.22);
+}
+
+.tg-datetime-picker__link:focus-visible{
+  outline:2px solid #38bdf8;
+  outline-offset:2px;
+}
+
+.tg-datetime-picker__status{
+  font-size:12px;
+  color:#475569;
+}
+
+body.dark-theme .tg-datetime-picker{
+  background:rgba(15,23,42,0.6);
+  border-color:rgba(148,163,184,0.45);
+}
+
+body.dark-theme .tg-datetime-picker__title,
+body.dark-theme .tg-datetime-picker__status{
+  color:#e2e8f0;
+}
+
+body.dark-theme .tg-datetime-picker .dp__input{
+  background:rgba(15,23,42,0.75);
+  border-color:rgba(148,163,184,0.55);
+  color:#e2e8f0;
+}
+
+body.dark-theme .tg-datetime-picker .dp__input:focus{
+  border-color:#38bdf8;
+  box-shadow:0 0 0 3px rgba(56,189,248,0.35);
+}
+
+body.dark-theme .tg-datetime-picker .dp__menu{
+  background:rgba(15,23,42,0.94);
+  border-color:rgba(148,163,184,0.55);
+  box-shadow:0 18px 36px rgba(2,6,23,0.55);
+  color:#e2e8f0;
+}
+
+body.dark-theme .tg-datetime-picker__link{
+  background:#38bdf8;
+  color:#0f172a;
+  box-shadow:0 8px 20px rgba(56,189,248,0.3);
+}
+
+body.dark-theme .tg-datetime-picker__link.is-muted{
+  background:#0f172a;
+  color:#e2e8f0;
+  box-shadow:0 6px 18px rgba(15,23,42,0.5);
+}
+
+.form-row.field-scheduled_at .datetime.tg-hidden-inputs{
+  display:none !important;
+}
+
+.tg-datetime-picker.is-disabled{
+  opacity:0.6;
+  pointer-events:none;
+}
+
+@media (max-width: 680px){
+  .tg-datetime-picker{
+    padding:10px;
+  }
+  .tg-datetime-picker__header{
+    flex-direction:column;
+    align-items:flex-start;
+  }
+  .tg-datetime-picker__actions{
+    width:100%;
+  }
+  .tg-datetime-picker__link{
+    flex:1 1 48%;
+    text-align:center;
+  }
+}

--- a/static/admin/post_form_tools.js
+++ b/static/admin/post_form_tools.js
@@ -1,0 +1,397 @@
+(function(){
+  const telegramLimits = {
+    text: 4096
+  };
+
+  function setCaret(textarea, start, end){
+    textarea.focus();
+    textarea.setSelectionRange(start, end);
+  }
+
+  function surroundSelection(textarea, before, after, placeholder){
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const value = textarea.value;
+    const hasSelection = start !== end;
+    const insert = hasSelection ? value.slice(start, end) : (placeholder || "");
+    const nextValue = value.slice(0, start) + before + insert + after + value.slice(end);
+    const cursor = start + before.length + insert.length;
+    textarea.value = nextValue;
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    setCaret(textarea, cursor, cursor);
+  }
+
+  function insertLink(textarea){
+    const url = window.prompt("Podaj adres URL (https://...)");
+    if (!url){
+      return;
+    }
+    const label = textarea.selectionStart !== textarea.selectionEnd
+      ? textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)
+      : window.prompt("Tekst linku", "link");
+    const safeLabel = label || "link";
+    const mark = `[${safeLabel}](${url})`;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const value = textarea.value;
+    textarea.value = value.slice(0, start) + mark + value.slice(end);
+    const caret = start + mark.length;
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    setCaret(textarea, caret, caret);
+  }
+
+  function stripFormatting(value){
+    return value
+      .replace(/\*\*(.*?)\*\*/gs, "$1")
+      .replace(/__(.*?)__/gs, "$1")
+      .replace(/_(.*?)_/gs, "$1")
+      .replace(/\*(.*?)\*/gs, "$1")
+      .replace(/~~(.*?)~~/gs, "$1")
+      .replace(/```([\s\S]*?)```/g, "$1")
+      .replace(/`([^`]+)`/g, "$1")
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)");
+  }
+
+  function clearFormatting(textarea){
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const value = textarea.value;
+    if (start !== end){
+      const selected = value.slice(start, end);
+      const cleaned = stripFormatting(selected);
+      textarea.value = value.slice(0, start) + cleaned + value.slice(end);
+      const caret = start + cleaned.length;
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      setCaret(textarea, caret, caret);
+    } else {
+      const cleaned = stripFormatting(value);
+      textarea.value = cleaned;
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      const caret = Math.min(start, cleaned.length);
+      setCaret(textarea, caret, caret);
+    }
+  }
+
+  function surroundCodeBlock(textarea){
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const value = textarea.value;
+    const selected = value.slice(start, end) || "kod";
+    const insert = "```\n" + selected + "\n```";
+    textarea.value = value.slice(0, start) + insert + value.slice(end);
+    const caret = start + insert.length;
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    setCaret(textarea, caret, caret);
+  }
+
+  function autoResize(textarea){
+    textarea.style.height = "auto";
+    const maxHeight = textarea.dataset.tgMaxHeight ? parseInt(textarea.dataset.tgMaxHeight, 10) : 720;
+    textarea.style.height = Math.min(textarea.scrollHeight + 2, maxHeight) + "px";
+  }
+
+  function updateCounter(wrapper, textarea){
+    const counter = wrapper.querySelector("[data-tg-editor-counter]");
+    if (!counter){
+      return;
+    }
+    const length = textarea.value.length;
+    counter.textContent = `${length} / ${telegramLimits.text}`;
+    if (length > telegramLimits.text){
+      counter.dataset.state = "overflow";
+    } else {
+      counter.dataset.state = "ok";
+    }
+  }
+
+  function initTextEditor(textarea){
+    if (!textarea || textarea.dataset.tgEditorInit){
+      return;
+    }
+    textarea.dataset.tgEditorInit = "1";
+    const compact = textarea.dataset.tgEditorCompact === "1";
+
+    const parent = textarea.parentElement;
+    if (!parent){
+      return;
+    }
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "tg-editor";
+    if (compact){
+      wrapper.setAttribute("data-compact", "1");
+    }
+
+    const toolbar = document.createElement("div");
+    toolbar.className = "tg-editor__toolbar";
+
+    const area = document.createElement("div");
+    area.className = "tg-editor__area";
+
+    const counter = document.createElement("p");
+    counter.className = "tg-editor__counter";
+    counter.setAttribute("data-tg-editor-counter", "1");
+    counter.textContent = `0 / ${telegramLimits.text}`;
+
+    parent.insertBefore(wrapper, textarea);
+    wrapper.appendChild(toolbar);
+    wrapper.appendChild(area);
+    area.appendChild(textarea);
+    wrapper.appendChild(counter);
+
+    textarea.classList.add("tg-editor__textarea");
+    textarea.dataset.tgMaxHeight = compact ? "420" : "720";
+
+    const buttons = [
+      { key: "bold", label: "B", title: "Pogrubienie (Markdown)", action: function(){ surroundSelection(textarea, "**", "**", "tekst"); } },
+      { key: "italic", label: "I", title: "Kursywa (Markdown)", action: function(){ surroundSelection(textarea, "_", "_", "tekst"); } },
+      { key: "strike", label: "S", title: "Przekreślenie", action: function(){ surroundSelection(textarea, "~~", "~~", "tekst"); } },
+      { key: "code", label: "<>", title: "Kod inline", action: function(){ surroundSelection(textarea, "`", "`", "kod"); } },
+      { key: "codeblock", label: "{ }", title: "Blok kodu", action: function(){ surroundCodeBlock(textarea); } },
+      { key: "link", label: "🔗", title: "Dodaj link (Markdown)", action: function(){ insertLink(textarea); } },
+      { key: "clear", label: "CLR", title: "Wyczyść formatowanie", css: "is-secondary", action: function(){ clearFormatting(textarea); } }
+    ];
+
+    buttons.forEach(function(btn){
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "tg-editor__button";
+      if (btn.css){
+        button.classList.add(btn.css);
+      }
+      button.textContent = btn.label;
+      button.title = btn.title;
+      button.addEventListener("click", function(event){
+        event.preventDefault();
+        btn.action();
+        autoResize(textarea);
+        updateCounter(wrapper, textarea);
+      });
+      toolbar.appendChild(button);
+    });
+
+    const enforceLimit = function(event){
+      const value = textarea.value;
+      if (value.length > telegramLimits.text){
+        textarea.value = value.slice(0, telegramLimits.text);
+        if (event){
+          event.preventDefault();
+        }
+      }
+    };
+
+    textarea.addEventListener("input", function(event){
+      enforceLimit(event);
+      autoResize(textarea);
+      updateCounter(wrapper, textarea);
+    });
+
+    textarea.addEventListener("change", function(event){
+      enforceLimit(event);
+      autoResize(textarea);
+      updateCounter(wrapper, textarea);
+    });
+
+    window.addEventListener("resize", function(){
+      window.requestAnimationFrame(function(){
+        autoResize(textarea);
+      });
+    });
+
+    autoResize(textarea);
+    updateCounter(wrapper, textarea);
+  }
+
+  function parseFromInputs(dateInput, timeInput){
+    const dateValue = (dateInput.value || "").trim();
+    const timeValue = (timeInput.value || "").trim();
+    if (!dateValue){
+      return null;
+    }
+    const iso = `${dateValue}T${timeValue || "00:00"}`;
+    const candidate = new Date(iso);
+    if (Number.isNaN(candidate.getTime())){
+      return null;
+    }
+    return candidate;
+  }
+
+  function formatForInputs(date){
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+    const h = String(date.getHours()).padStart(2, "0");
+    const min = String(date.getMinutes()).padStart(2, "0");
+    const s = String(date.getSeconds()).padStart(2, "0");
+    return {
+      date: `${y}-${m}-${d}`,
+      time: `${h}:${min}:${s}`
+    };
+  }
+
+  function formatHuman(date){
+    return date.toLocaleString(undefined, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit"
+    });
+  }
+
+  function initDatePicker(){
+    const dateInput = document.getElementById("id_scheduled_at_0");
+    const timeInput = document.getElementById("id_scheduled_at_1");
+    if (!dateInput || !timeInput){
+      return;
+    }
+    if (typeof Vue === "undefined" || typeof VueDatePicker === "undefined"){
+      console.warn("Vue 3 DatePicker not available");
+      return;
+    }
+
+    const row = dateInput.closest(".form-row") || dateInput.parentElement;
+    if (!row){
+      return;
+    }
+
+    const datetimeWrapper = dateInput.closest(".datetime");
+    if (datetimeWrapper){
+      datetimeWrapper.classList.add("tg-hidden-inputs");
+    } else {
+      dateInput.style.display = "none";
+      timeInput.style.display = "none";
+    }
+
+    const mountPoint = document.createElement("div");
+    mountPoint.className = "tg-datetime-picker";
+    mountPoint.setAttribute("data-tg-datepicker", "1");
+    const help = row.querySelector(".help");
+    row.insertBefore(mountPoint, help);
+
+    const initial = parseFromInputs(dateInput, timeInput);
+    const { createApp, ref, computed, watch } = Vue;
+    const schedulePicker = {
+      setManual: function(){}
+    };
+
+    const app = createApp({
+      components: {
+        Datepicker: VueDatePicker
+      },
+      setup: function(){
+        const modelValue = ref(initial);
+        const manualMode = ref(true);
+        const disabled = computed(function(){ return !manualMode.value; });
+        const humanPreview = computed(function(){
+          if (!modelValue.value){
+            return "Brak wybranej daty";
+          }
+          return formatHuman(modelValue.value);
+        });
+
+        watch(modelValue, function(next){
+          if (!next){
+            dateInput.value = "";
+            timeInput.value = "";
+          } else {
+            const formatted = formatForInputs(next);
+            dateInput.value = formatted.date;
+            timeInput.value = formatted.time;
+          }
+          dateInput.dispatchEvent(new Event("input", { bubbles: true }));
+          timeInput.dispatchEvent(new Event("input", { bubbles: true }));
+        });
+
+        schedulePicker.setManual = function(isManual){
+          manualMode.value = !!isManual;
+          if (!manualMode.value){
+            modelValue.value = null;
+          }
+        };
+
+        schedulePicker.getManual = function(){
+          return manualMode.value;
+        };
+
+        schedulePicker.setFromInputs = function(){
+          const parsed = parseFromInputs(dateInput, timeInput);
+          modelValue.value = parsed;
+        };
+
+        const pickNow = function(){
+          const now = new Date();
+          modelValue.value = now;
+        };
+
+        const clearAll = function(){
+          modelValue.value = null;
+        };
+
+        return {
+          modelValue,
+          disabled,
+          humanPreview,
+          pickNow,
+          clearAll
+        };
+      },
+      template: `
+        <div :class="['tg-datetime-picker__inner']">
+          <div class="tg-datetime-picker__header">
+            <p class="tg-datetime-picker__title">Termin publikacji</p>
+            <span class="tg-datetime-picker__status">{{ humanPreview }}</span>
+          </div>
+          <date-picker
+            v-model="modelValue"
+            :is-24="true"
+            :enable-time-picker="true"
+            :time-picker-inline="true"
+            :auto-apply="true"
+            :clearable="false"
+            :teleport="false"
+            :allow-prevent-default="true"
+            placeholder="Wybierz datę i godzinę"
+            locale="pl"
+          ></date-picker>
+          <div class="tg-datetime-picker__actions">
+            <button type="button" class="tg-datetime-picker__link" @click="pickNow" :disabled="disabled">Teraz</button>
+            <button type="button" class="tg-datetime-picker__link is-muted" @click="clearAll" :disabled="disabled">Wyczyść</button>
+          </div>
+        </div>
+      `
+    });
+
+    app.mount(mountPoint);
+
+    const scheduleModeSelect = document.getElementById("id_schedule_mode");
+    const syncManual = function(){
+      const manual = !scheduleModeSelect || scheduleModeSelect.value === "MANUAL";
+      schedulePicker.setManual(manual);
+      mountPoint.classList.toggle("is-disabled", !manual);
+      if (!manual){
+        dateInput.value = "";
+        timeInput.value = "";
+        dateInput.dispatchEvent(new Event("input", { bubbles: true }));
+        timeInput.dispatchEvent(new Event("input", { bubbles: true }));
+      } else {
+        schedulePicker.setFromInputs();
+      }
+    };
+
+    if (scheduleModeSelect){
+      scheduleModeSelect.addEventListener("change", syncManual);
+    }
+    syncManual();
+
+    window.tgSchedulePicker = schedulePicker;
+    if (initial){
+      schedulePicker.setFromInputs();
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    document.querySelectorAll("textarea[data-tg-editor]").forEach(initTextEditor);
+    initDatePicker();
+  });
+})();

--- a/templates/admin/posts/change_form.html
+++ b/templates/admin/posts/change_form.html
@@ -7,6 +7,9 @@
   {{ block.super }}
   <script src="{% url 'admin:jsi18n' %}"></script>
   {{ media }}
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js" defer></script>
+  <script src="https://unpkg.com/@vuepic/vue-datepicker@latest" defer></script>
+  <script defer src="{% static 'admin/post_form_tools.js' %}"></script>
 {% endblock %}
 
 {% block extrastyle %}
@@ -14,6 +17,8 @@
   <link rel="stylesheet" href="{% static 'admin/css/forms.css' %}">
   <link rel="stylesheet" href="{% static 'admin/post_cards.css' %}">
   <link rel="stylesheet" href="{% static 'admin/post_edit.css' %}">
+  <link rel="stylesheet" href="https://unpkg.com/@vuepic/vue-datepicker@latest/dist/main.css">
+  <link rel="stylesheet" href="{% static 'admin/post_form_tools.css' %}">
 {% endblock %}
 
 {% block coltype %}colM{% endblock %}

--- a/templates/admin/posts/reschedule.html
+++ b/templates/admin/posts/reschedule.html
@@ -1,9 +1,18 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}
+{% load i18n static %}
 
 {% block extrahead %}
   {{ block.super }}
   {{ media }}
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js" defer></script>
+  <script src="https://unpkg.com/@vuepic/vue-datepicker@latest" defer></script>
+  <script defer src="{% static 'admin/post_form_tools.js' %}"></script>
+{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="https://unpkg.com/@vuepic/vue-datepicker@latest/dist/main.css">
+  <link rel="stylesheet" href="{% static 'admin/post_form_tools.css' %}">
 {% endblock %}
 
 {% block content %}

--- a/templates/admin/posts/rewrite.html
+++ b/templates/admin/posts/rewrite.html
@@ -1,9 +1,15 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}
+{% load i18n static %}
 
 {% block extrahead %}
   {{ block.super }}
   {{ media }}
+  <script defer src="{% static 'admin/post_form_tools.js' %}"></script>
+{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'admin/post_form_tools.css' %}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Podsumowanie
- dodano mobilny edytor tekstu dla pól wpisów i promptów z limitem Telegrama oraz zestawem skrótów formatowania
- zintegrowano Vue 3 Datepicker w formularzu planowania publikacji, zachowując synchronizację z istniejącymi polami Django
- rozszerzono szablony administracyjne o nowe zasoby CSS/JS zapewniające spójny wygląd w trybie jasnym i ciemnym

## Testy
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68d905a9158083278cd0754debe3744e