### PR TITLE
Walidacja długości tekstu w PostForm na podstawie danych formularza

### DIFF
--- a/apps/posts/admin.py
+++ b/apps/posts/admin.py
@@ -39,7 +39,7 @@ from .tasks import (
 
 logger = logging.getLogger(__name__)
 from .drafts import iter_missing_draft_requirements
-from .validators import validate_post_text_for_channel
+from .validators import validate_post_text_for_channel, validate_text_for_channel
 
 
 def enqueue_missing_drafts(channels: Iterable[Channel]) -> tuple[int, int]:
@@ -131,9 +131,10 @@ class PostForm(forms.ModelForm):
 
     def clean(self):
         cleaned = super().clean()
-        obj = self.instance
-        if obj and obj.channel_id:
-            validate_post_text_for_channel(obj)
+        text = cleaned.get("text")
+        channel = cleaned.get("channel")
+        if channel:
+            validate_text_for_channel(text, channel)
         return cleaned
 
     def clean_source_url(self) -> str:

--- a/apps/posts/tests/test_admin_forms.py
+++ b/apps/posts/tests/test_admin_forms.py
@@ -51,6 +51,21 @@ class PostFormTests(TestCase):
         )
         self.assertTrue(form.is_valid())
 
+    def test_uses_submitted_text_not_instance_text_for_validation(self) -> None:
+        self.post.text = "ok"
+        form = PostForm(
+            data={
+                "channel": self.channel.pk,
+                "text": "x" * 50,
+                "source_url": "",
+                "status": Post.Status.DRAFT,
+                "schedule_mode": "AUTO",
+            },
+            instance=self.post,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("Za długie", " ".join(form.non_field_errors()))
+
     def test_source_url_can_be_set_and_is_stripped(self) -> None:
         form = PostForm(
             data={

--- a/apps/posts/validators.py
+++ b/apps/posts/validators.py
@@ -1,7 +1,11 @@
 from django import forms
 
+
+def validate_text_for_channel(text, channel):
+    text = text or ""
+    if channel and len(text) > channel.max_chars:
+        raise forms.ValidationError(f"Za długie (> {channel.max_chars} znaków)")
+
+
 def validate_post_text_for_channel(post):
-    t = post.text
-    ch = post.channel
-    if len(t) > ch.max_chars:
-        raise forms.ValidationError(f"Za długie (> {ch.max_chars} znaków)")
+    validate_text_for_channel(post.text, post.channel)


### PR DESCRIPTION
### Motivation
- Poprawić walidację długości posta, aby sprawdzać faktycznie przesłany tekst z formularza zamiast polegać wyłącznie na `instance`, co mogło przepuścić przypadki, gdy `instance.text` był inny niż `data["text"]`.

### Description
- Zmieniono `PostForm.clean()` tak, by pobierał `text` i `channel` z `cleaned_data` i walidował je bezpośrednio zamiast mutować/odczytywać tylko `instance` (plik `apps/posts/admin.py`).
- Dodano pomocniczą funkcję `validate_text_for_channel(text, channel)` i przekierowano do niej istniejącą `validate_post_text_for_channel(post)` w `apps/posts/validators.py` w celu zachowania kompatybilności.
- Zaktualizowano importy w `apps/posts/admin.py` aby używać nowego helpera `validate_text_for_channel`.
- Dodano test regresyjny `test_uses_submitted_text_not_instance_text_for_validation` w `apps/posts/tests/test_admin_forms.py`, sprawdzający przypadek, gdy `instance.text` jest krótki, ale `data["text"]` przekracza limit kanału.

### Testing
- Uruchomiono `pytest apps/posts/tests/test_admin_forms.py` i wszystkie testy zakończyły się powodzeniem (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b076ded4832090a2d5ad0f04fce2)