### PR TITLE
Fix draft-generation prompt role ordering for stronger channel rule adherence

### DIFF
--- a/apps/posts/services.py
+++ b/apps/posts/services.py
@@ -1105,8 +1105,8 @@ def build_draft_generation_prompt(
         recent_headlines=headlines,
     )
     return {
-        "system": instructions,
-        "user": _channel_system_prompt(channel),
+        "system": _channel_system_prompt(channel),
+        "user": instructions,
     }
 
 
@@ -1922,8 +1922,8 @@ def gpt_generate_post_payload(channel: Channel, article: dict[str, Any] | None =
             recent_headlines=headlines,
         )
         raw = gpt_generate_text(
-            system_prompt,
             channel_prompt,
+            system_prompt,
             log_context={
                 "channel_id": channel.id,
                 "attempt": attempt,

--- a/apps/posts/tests/test_channel_prompts.py
+++ b/apps/posts/tests/test_channel_prompts.py
@@ -28,22 +28,22 @@ class ChannelPromptPropagationTest(TestCase):
             services.gpt_generate_post_payload(self.channel)
 
         system_prompt, user_prompt = mock_gpt.call_args[0][:2]
-        self.assertIn("Zwróć dokładnie jeden obiekt JSON", system_prompt)
-        self.assertIn("resolver (np. twitter/telegram/instagram/rss)", system_prompt)
-        self.assertIn("reference – obiekt z prawdziwymi identyfikatorami", system_prompt)
-        self.assertIn("reference.source_locator", system_prompt)
-        self.assertIn("angielskich nazw pól", system_prompt)
-        self.assertIn("Treść posta oraz wszystkie media muszą opisywać to samo wydarzenie", system_prompt)
-        self.assertIn("Jeśli media pochodzą z artykułu lub innego źródła", system_prompt)
-        self.assertNotIn("linia1", system_prompt)
-        self.assertNotIn("linia2", system_prompt)
+        self.assertIn("Wytyczne kanału", system_prompt)
+        self.assertIn("maksymalnie 321 znaków", system_prompt)
+        self.assertNotIn("emoji", system_prompt.lower())
+        self.assertIn("linia1", system_prompt)
+        self.assertIn("linia2", system_prompt)
+        self.assertIn("Nie dodawaj linków w treści.", system_prompt)
 
-        self.assertIn("Wytyczne kanału", user_prompt)
-        self.assertIn("maksymalnie 321 znaków", user_prompt)
-        self.assertNotIn("emoji", user_prompt.lower())
-        self.assertIn("linia1", user_prompt)
-        self.assertIn("linia2", user_prompt)
-        self.assertIn("Nie dodawaj linków w treści.", user_prompt)
+        self.assertIn("Zwróć dokładnie jeden obiekt JSON", user_prompt)
+        self.assertIn("resolver (np. twitter/telegram/instagram/rss)", user_prompt)
+        self.assertIn("reference – obiekt z prawdziwymi identyfikatorami", user_prompt)
+        self.assertIn("reference.source_locator", user_prompt)
+        self.assertIn("angielskich nazw pól", user_prompt)
+        self.assertIn("Treść posta oraz wszystkie media muszą opisywać to samo wydarzenie", user_prompt)
+        self.assertIn("Jeśli media pochodzą z artykułu lub innego źródła", user_prompt)
+        self.assertNotIn("linia1", user_prompt)
+        self.assertNotIn("linia2", user_prompt)
 
     def test_rewrite_text_uses_same_channel_rules(self):
         with patch("apps.posts.services.gpt_generate_text") as mock_gpt:
@@ -82,9 +82,9 @@ class ChannelPromptPropagationTest(TestCase):
         self.assertEqual(payload["post"]["text"], "Nowy raport o sytuacji")
         self.assertEqual(mock_gpt.call_count, 2)
 
-        second_system_prompt = mock_gpt.call_args_list[1][0][0]
-        self.assertIn("nie powielaj tematów", second_system_prompt.lower())
-        self.assertIn("Powtarzalny wpis o dronach", second_system_prompt)
+        second_user_prompt = mock_gpt.call_args_list[1][0][1]
+        self.assertIn("nie powielaj tematów", second_user_prompt.lower())
+        self.assertIn("Powtarzalny wpis o dronach", second_user_prompt)
 
     def test_channel_sources_are_listed_in_prompt(self):
         primary = ChannelSource.objects.create(
@@ -110,13 +110,13 @@ class ChannelPromptPropagationTest(TestCase):
         mock_select.assert_called_with(self.channel, limit=1)
 
         system_prompt, user_prompt = mock_gpt.call_args[0][:2]
-        self.assertNotIn(primary.url, system_prompt)
+        self.assertIn(primary.url, system_prompt)
         self.assertNotIn(secondary.url, system_prompt)
-        self.assertIn(primary.url, user_prompt)
+        self.assertNotIn("Preferuj", system_prompt)
+        self.assertNotIn("źródło:", system_prompt)
+        self.assertNotIn("priorytet", system_prompt)
+        self.assertNotIn(primary.url, user_prompt)
         self.assertNotIn(secondary.url, user_prompt)
-        self.assertNotIn("Preferuj", user_prompt)
-        self.assertNotIn("źródło:", user_prompt)
-        self.assertNotIn("priorytet", user_prompt)
 
     def test_recent_headlines_are_included_for_last_24_hours(self):
         Post.objects.create(
@@ -144,11 +144,11 @@ class ChannelPromptPropagationTest(TestCase):
             mock_gpt.return_value = json.dumps({"post": {"text": "tekst"}, "media": []})
             services.gpt_generate_post_payload(self.channel)
 
-        system_prompt, _ = mock_gpt.call_args[0][:2]
-        self.assertIn("nie powielaj tematów", system_prompt.lower())
-        self.assertIn("Nagłówek A", system_prompt)
-        self.assertIn("Drugi post bez entera", system_prompt)
-        self.assertNotIn("Stary nagłówek", system_prompt)
+        _, user_prompt = mock_gpt.call_args[0][:2]
+        self.assertIn("nie powielaj tematów", user_prompt.lower())
+        self.assertIn("Nagłówek A", user_prompt)
+        self.assertIn("Drugi post bez entera", user_prompt)
+        self.assertNotIn("Stary nagłówek", user_prompt)
 
     def test_recent_headlines_list_includes_up_to_40_entries(self):
         for idx in range(41):
@@ -163,14 +163,14 @@ class ChannelPromptPropagationTest(TestCase):
             mock_gpt.return_value = json.dumps({"post": {"text": "tekst"}, "media": []})
             services.gpt_generate_post_payload(self.channel)
 
-        system_prompt, _ = mock_gpt.call_args[0][:2]
+        _, user_prompt = mock_gpt.call_args[0][:2]
         prefixes = tuple(f"{n}. " for n in range(1, 45))
         enumerated_lines = [
-            line for line in system_prompt.splitlines() if line.strip().startswith(prefixes)
+            line for line in user_prompt.splitlines() if line.strip().startswith(prefixes)
         ]
         self.assertEqual(40, len(enumerated_lines))
-        self.assertIn("Nagłówek 40", system_prompt)
-        self.assertNotIn("Nagłówek 0", system_prompt)
+        self.assertIn("Nagłówek 40", user_prompt)
+        self.assertNotIn("Nagłówek 0", user_prompt)
 
     def test_article_headlines_are_sanitized_in_prompt(self):
         article = {
@@ -181,12 +181,12 @@ class ChannelPromptPropagationTest(TestCase):
             mock_gpt.return_value = json.dumps({"post": {"text": "tekst"}, "media": []})
             services.gpt_generate_post_payload(self.channel, article=article)
 
-        system_prompt, _ = mock_gpt.call_args[0][:2]
-        self.assertIn("nie powielaj tematów:", system_prompt)
-        self.assertIn("1. Pilne Alarm", system_prompt)
-        self.assertIn("2. Drugi nagłówek", system_prompt)
-        self.assertNotIn("🔥", system_prompt)
-        self.assertNotIn("@", system_prompt)
+        _, user_prompt = mock_gpt.call_args[0][:2]
+        self.assertIn("nie powielaj tematów:", user_prompt)
+        self.assertIn("1. Pilne Alarm", user_prompt)
+        self.assertIn("2. Drugi nagłówek", user_prompt)
+        self.assertNotIn("🔥", user_prompt)
+        self.assertNotIn("@", user_prompt)
 
     def test_topics_to_avoid_do_not_duplicate_recent_headlines(self):
         Post.objects.create(
@@ -204,9 +204,9 @@ class ChannelPromptPropagationTest(TestCase):
             mock_gpt.return_value = json.dumps({"post": {"text": "tekst"}, "media": []})
             services.gpt_generate_post_payload(self.channel, article=article)
 
-        system_prompt, _ = mock_gpt.call_args[0][:2]
+        _, user_prompt = mock_gpt.call_args[0][:2]
         duplicate_lines = [
-            line for line in system_prompt.splitlines() if "Powielony nagłówek" in line
+            line for line in user_prompt.splitlines() if "Powielony nagłówek" in line
         ]
         self.assertEqual(1, len(duplicate_lines))
-        self.assertIn("Dodatkowy temat", system_prompt)
+        self.assertIn("Dodatkowy temat", user_prompt)


### PR DESCRIPTION
### Motivation
- Channel-level constraints and style should be enforced as the `system` role so the model prioritises channel rules over task formatting.
- The draft-generation flow previously sent schema/instruction text as `system` and channel rules as `user`, weakening enforcement of policy/style.

### Description
- Swap the prompt roles returned by `build_draft_generation_prompt` so `system` contains `_channel_system_prompt(channel)` and `user` contains the generation instructions (`_build_user_prompt`).
- Update `gpt_generate_post_payload` to call `gpt_generate_text` with the corrected argument order (`system=channel_prompt`, `user=system_prompt` renamed locally to the generation instructions).
- Adjust `apps/posts/tests/test_channel_prompts.py` assertions to match the new role assignment and to keep coverage for sources, deduplication and headline logic.
- Changes applied to `apps/posts/services.py` and `apps/posts/tests/test_channel_prompts.py`.

### Testing
- Ran `pytest -q apps/posts/tests/test_channel_prompts.py` and all tests passed (`8 passed`).
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d826c586e48320b95a207dfa0d30d6)